### PR TITLE
운동시설 관리자 회원 탈퇴 API 개발

### DIFF
--- a/helparty/src/main/java/com/hamryt/helparty/controller/GymController.java
+++ b/helparty/src/main/java/com/hamryt/helparty/controller/GymController.java
@@ -12,6 +12,7 @@ import com.hamryt.helparty.service.session.SessionService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,6 +44,14 @@ public class GymController {
         @Valid @RequestBody UpdateGymRequest updateGymRequest
     ) {
         return gymService.updateGym(id, updateGymRequest);
+    }
+    
+    @LoginValidation
+    @DeleteMapping("{id}")
+    public void deleteGym(
+        @ValidateUser(type = UserType.GYM) @PathVariable("id") Long id
+    ) {
+        gymService.deleteGym(id);
     }
     
 }

--- a/helparty/src/main/java/com/hamryt/helparty/controller/UserController.java
+++ b/helparty/src/main/java/com/hamryt/helparty/controller/UserController.java
@@ -4,7 +4,6 @@ import com.hamryt.helparty.aop.ValidateUser;
 import com.hamryt.helparty.dto.UserType;
 import com.hamryt.helparty.dto.user.request.SignUpUserRequest;
 import com.hamryt.helparty.dto.user.request.UpdateUserRequest;
-import com.hamryt.helparty.dto.user.request.UserDeleteRequest;
 import com.hamryt.helparty.dto.user.response.SignUpUserResponse;
 import com.hamryt.helparty.dto.user.response.UpdateUserResponse;
 import com.hamryt.helparty.interceptor.LoginValidation;
@@ -52,9 +51,8 @@ public class UserController {
     @LoginValidation
     @DeleteMapping("{id}")
     public void deleteUser(
-        @ValidateUser(type = UserType.USER) @PathVariable("id") Long id,
-        @Valid @RequestBody UserDeleteRequest userDeleteRequest
+        @ValidateUser(type = UserType.USER) @PathVariable("id") Long id
     ) {
-        userService.deleteUser(userDeleteRequest);
+        userService.deleteUser(id);
     }
 }

--- a/helparty/src/main/java/com/hamryt/helparty/exception/gym/GymDeleteFailedException.java
+++ b/helparty/src/main/java/com/hamryt/helparty/exception/gym/GymDeleteFailedException.java
@@ -1,0 +1,8 @@
+package com.hamryt.helparty.exception.gym;
+
+public class GymDeleteFailedException extends RuntimeException {
+    
+    public GymDeleteFailedException(Long id) {
+        super("Delete Gym by ID Failed : " + id);
+    }
+}

--- a/helparty/src/main/java/com/hamryt/helparty/exception/gym/InsertGymFailedException.java
+++ b/helparty/src/main/java/com/hamryt/helparty/exception/gym/InsertGymFailedException.java
@@ -1,8 +1,8 @@
 package com.hamryt.helparty.exception.gym;
 
-public class InsertGymFailedExcetpion extends RuntimeException {
+public class InsertGymFailedException extends RuntimeException {
     
-    public InsertGymFailedExcetpion() {
+    public InsertGymFailedException() {
         super("Insert Gym failed exception");
     }
     

--- a/helparty/src/main/java/com/hamryt/helparty/exception/user/UserDeleteFailedException.java
+++ b/helparty/src/main/java/com/hamryt/helparty/exception/user/UserDeleteFailedException.java
@@ -1,7 +1,8 @@
 package com.hamryt.helparty.exception.user;
 
-public class UserDeleteFailedException extends RuntimeException{
-    public UserDeleteFailedException(String email){
-        super("Delete User By email Failed : " + email);
+public class UserDeleteFailedException extends RuntimeException {
+    
+    public UserDeleteFailedException(Long id) {
+        super("Delete User By Id Failed : " + id);
     }
 }

--- a/helparty/src/main/java/com/hamryt/helparty/mapper/GymMapper.java
+++ b/helparty/src/main/java/com/hamryt/helparty/mapper/GymMapper.java
@@ -14,4 +14,6 @@ public interface GymMapper {
     int updateGym(UpdateGymResponse updateGymResponse);
     
     String findGymEmailById(Long id);
+    
+    int deleteGymById(Long id);
 }

--- a/helparty/src/main/java/com/hamryt/helparty/mapper/UserMapper.java
+++ b/helparty/src/main/java/com/hamryt/helparty/mapper/UserMapper.java
@@ -6,20 +6,20 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface UserMapper {
-
+    
     int insertUser(UserDTO user);
-
+    
     boolean isExistsEmail(String email);
-
+    
     UserDTO findUserByEmailAndPassword(String email, String password);
-
+    
     UserDTO findUserById(Long id);
-
-    int deleteUserByEmailAndPassword(String email, String password);
-
+    
     int updateUser(UpdateUserResponse updateUserResponse);
-
+    
     UserDTO findUserByEmail(String email);
     
     String findUserEmailById(Long id);
+    
+    int deleteUserById(Long id);
 }

--- a/helparty/src/main/java/com/hamryt/helparty/service/gym/GymService.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/gym/GymService.java
@@ -15,4 +15,6 @@ public interface GymService {
     UpdateGymResponse updateGym(Long id, UpdateGymRequest updateGymRequest);
     
     String findGymEmailById(Long id);
+    
+    void deleteGym(Long id);
 }

--- a/helparty/src/main/java/com/hamryt/helparty/service/gym/GymServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/gym/GymServiceImpl.java
@@ -6,6 +6,7 @@ import com.hamryt.helparty.dto.gym.request.SignUpGymRequest;
 import com.hamryt.helparty.dto.gym.request.UpdateGymRequest;
 import com.hamryt.helparty.dto.gym.response.SignUpGymResponse;
 import com.hamryt.helparty.dto.gym.response.UpdateGymResponse;
+import com.hamryt.helparty.exception.gym.GymDeleteFailedException;
 import com.hamryt.helparty.exception.gym.GymNotFoundByIdException;
 import com.hamryt.helparty.exception.gym.GymNotFoundException;
 import com.hamryt.helparty.exception.gym.InsertGymFailedExcetpion;
@@ -80,6 +81,13 @@ public class GymServiceImpl implements GymService {
     public String findGymEmailById(Long id) {
         return Optional.ofNullable(gymMapper.findGymEmailById(id))
             .orElseThrow(() -> new GymNotFoundByIdException(id));
+    }
+    
+    @Transactional
+    public void deleteGym(Long id) {
+        if (gymMapper.deleteGymById(id) != 1) {
+            throw new GymDeleteFailedException(id);
+        }
     }
     
     @Transactional(readOnly = true)

--- a/helparty/src/main/java/com/hamryt/helparty/service/gym/GymServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/gym/GymServiceImpl.java
@@ -9,7 +9,7 @@ import com.hamryt.helparty.dto.gym.response.UpdateGymResponse;
 import com.hamryt.helparty.exception.gym.GymDeleteFailedException;
 import com.hamryt.helparty.exception.gym.GymNotFoundByIdException;
 import com.hamryt.helparty.exception.gym.GymNotFoundException;
-import com.hamryt.helparty.exception.gym.InsertGymFailedExcetpion;
+import com.hamryt.helparty.exception.gym.InsertGymFailedException;
 import com.hamryt.helparty.exception.user.DoesNotMatchUserType;
 import com.hamryt.helparty.exception.user.EmailExistedException;
 import com.hamryt.helparty.exception.user.UpdateFailedException;
@@ -51,7 +51,7 @@ public class GymServiceImpl implements GymService {
             .build();
         
         if (gymMapper.insertGym(newGym) != 1) {
-            throw new InsertGymFailedExcetpion();
+            throw new InsertGymFailedException();
         }
         
         return SignUpGymResponse.of(newGym);

--- a/helparty/src/main/java/com/hamryt/helparty/service/user/UserService.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/user/UserService.java
@@ -3,25 +3,24 @@ package com.hamryt.helparty.service.user;
 import com.hamryt.helparty.dto.user.UserDTO;
 import com.hamryt.helparty.dto.user.request.SignUpUserRequest;
 import com.hamryt.helparty.dto.user.request.UpdateUserRequest;
-import com.hamryt.helparty.dto.user.request.UserDeleteRequest;
 import com.hamryt.helparty.dto.user.response.SignUpUserResponse;
 import com.hamryt.helparty.dto.user.response.UpdateUserResponse;
 
 
 public interface UserService {
-
+    
     SignUpUserResponse insertUser(SignUpUserRequest userDto);
-
+    
     boolean isExistsEmail(String email);
-
+    
     UserDTO findUserByEmail(String email);
-
+    
     UserDTO findUserByEmailAndPassword(String email, String password);
-
-    void deleteUser(UserDeleteRequest userDeleteRequest);
-
+    
+    void deleteUser(Long id);
+    
     UpdateUserResponse updateUser(Long id, UpdateUserRequest updateUserRequest);
-
+    
     UserDTO getUserById(Long id);
     
     String findUserEmailById(Long id);

--- a/helparty/src/main/resources/mybatis/mapper/UserMapper.xml
+++ b/helparty/src/main/resources/mybatis/mapper/UserMapper.xml
@@ -7,15 +7,18 @@
   <insert id="insertUser" useGeneratedKeys="true" keyProperty="id"
     parameterType="com.hamryt.helparty.dto.user.UserDTO">
     INSERT INTO user (email, password, name, phone_number, address_code, address_detail, user_type)
-    VALUES(#{email}, #{password}, #{name}, #{phoneNumber}, #{addressCode}, #{addressDetail}, #{userType})
+    VALUES(#{email}, #{password}, #{name}, #{phoneNumber}, #{addressCode}, #{addressDetail},
+    #{userType})
   </insert>
 
   <select id="findUserById" resultType="com.hamryt.helparty.dto.user.UserDTO">
-    SELECT id, email, name, password, phone_number, address_code, address_detail FROM user WHERE id=#{id}
+    SELECT id, email, name, password, phone_number, address_code, address_detail FROM user WHERE
+    id=#{id}
   </select>
 
   <select id="findUserByEmail" resultType="com.hamryt.helparty.dto.user.UserDTO">
-    SELECT id, email, name, password, phone_number, address_code, address_detail FROM user WHERE email=#{email}
+    SELECT id, email, name, password, phone_number, address_code, address_detail FROM user WHERE
+    email=#{email}
   </select>
 
   <select id="isExistsEmail" resultType="_boolean">
@@ -38,7 +41,7 @@
   </select>
 
   <select id="findUserEmailById" resultType="String">
-    SELECT email FROM user  WHERE id=#{id}
+    SELECT email FROM user WHERE id=#{id}
   </select>
 
   <update id="updateUser" parameterType="com.hamryt.helparty.dto.user.response.UpdateUserResponse">
@@ -52,7 +55,7 @@
   </update>
 
   <delete id="deleteUserByEmailAndPassword">
-    DELETE FROM user WHERE email=#{email} AND password=#{password}
+    DELETE FROM user WHERE id=#{id}
   </delete>
 
 </mapper>

--- a/helparty/src/main/resources/mybatis/mapper/gymMapper.xml
+++ b/helparty/src/main/resources/mybatis/mapper/gymMapper.xml
@@ -45,4 +45,8 @@
     WHERE id = #{id}
   </update>
 
+  <delete id="deleteGymById">
+    DELETE FROM gym WHERE id=#{id}
+  </delete>
+
 </mapper>

--- a/helparty/src/test/java/com/hamryt/helparty/controller/GymControllerTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/controller/GymControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -93,6 +94,15 @@ class GymControllerTest {
             .andExpect(status().isOk());
         
         verify(gymService).updateGym(eq(1004L), any());
+    }
+    
+    @Test
+    @DisplayName("운동시설 관리자 계정 삭제 성공시 상태 코드 200을 반환")
+    public void delete_Success() throws Exception {
+        mvc.perform(delete("/gyms/1004"))
+            .andExpect(status().isOk());
+        
+        verify(gymService).deleteGym(1004L);
     }
     
     private UpdateGymRequest getUpdateGymRequest(String gymName, String password,

--- a/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hamryt.helparty.dto.UserType;
 import com.hamryt.helparty.dto.gym.GymDTO;
@@ -12,6 +13,7 @@ import com.hamryt.helparty.dto.gym.request.SignUpGymRequest;
 import com.hamryt.helparty.dto.gym.request.UpdateGymRequest;
 import com.hamryt.helparty.dto.gym.response.SignUpGymResponse;
 import com.hamryt.helparty.dto.gym.response.UpdateGymResponse;
+import com.hamryt.helparty.exception.gym.GymDeleteFailedException;
 import com.hamryt.helparty.exception.gym.GymNotFoundException;
 import com.hamryt.helparty.exception.gym.InsertGymFailedExcetpion;
 import com.hamryt.helparty.exception.user.DoesNotMatchUserType;
@@ -190,6 +192,29 @@ class GymServiceImplTest {
         
         assertEquals("This gym does not exists with this email : test@example.com",
             gymNotFoundException.getMessage());
+    }
+    
+    @Test
+    @DisplayName("운동 시설 관리자 계정 삭제 성공")
+    public void deleteGym_Success() {
+        given(gymMapper.deleteGymById(eq(1004L))).willReturn(1);
+        
+        gymService.deleteGym(1004L);
+        
+        verify(gymMapper).deleteGymById(1004L);
+    }
+    
+    @Test
+    @DisplayName("운동 시설 관리자 계정 삭제 실패")
+    public void deleteGym_Fail() {
+        given(gymMapper.deleteGymById(eq(1004L))).willReturn(0);
+        
+        GymDeleteFailedException gymDeleteFailedException
+            = assertThrows(GymDeleteFailedException.class,
+            () -> gymService.deleteGym(1004L));
+        
+        assertEquals("Delete Gym by ID Failed : 1004",
+            gymDeleteFailedException.getMessage());
     }
     
 }

--- a/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
@@ -205,7 +205,7 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("운동 시설 관리자 계정 삭제 실패")
+    @DisplayName("운동 시설 관리자 계정 삭제 실패 : 삭제 쿼리 실패")
     public void deleteGym_Fail() {
         given(gymMapper.deleteGymById(eq(1004L))).willReturn(0);
         

--- a/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/service/gym/GymServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.hamryt.helparty.service.gym;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -15,7 +15,7 @@ import com.hamryt.helparty.dto.gym.response.SignUpGymResponse;
 import com.hamryt.helparty.dto.gym.response.UpdateGymResponse;
 import com.hamryt.helparty.exception.gym.GymDeleteFailedException;
 import com.hamryt.helparty.exception.gym.GymNotFoundException;
-import com.hamryt.helparty.exception.gym.InsertGymFailedExcetpion;
+import com.hamryt.helparty.exception.gym.InsertGymFailedException;
 import com.hamryt.helparty.exception.user.DoesNotMatchUserType;
 import com.hamryt.helparty.exception.user.EmailExistedException;
 import com.hamryt.helparty.exception.user.UpdateFailedException;
@@ -90,7 +90,7 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("운동 시설 관리자 계정정보 수정 실패 : 수정 쿼리 실패")
+    @DisplayName("운동 시설 관리자 계정정보 수정 실패 : 데이터베이스 수정 명령에 실패하면 UpdateFailedException을 발생시킨다.")
     public void updateGym_Fail() {
         
         given(gymMapper.updateGym(any())).willReturn(2);
@@ -129,7 +129,7 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("운동 시설 관리자 회원 가입 실패 : 이미 존재하는 이메일")
+    @DisplayName("운동 시설 관리자 회원 가입 실패 : 이미 존재하는 이메일 예외")
     public void createGym_Fail_EmailExistedException() {
         
         given(gymMapper.isExistsEmail(any())).willReturn(true);
@@ -143,18 +143,18 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("운동 시설 관리자 회원 가입 실패 : 삽입 쿼리 실패")
+    @DisplayName("운동 시설 관리자 회원 가입 실패 : 데이터베이스 삽입 명령에 실패하면 InsertGymFailedExcetpion을 발생시킨다.")
     public void createGym_Fail_InsertGymFailException() {
         
         given(gymMapper.isExistsEmail(any())).willReturn(false);
         given(gymMapper.insertGym(any())).willReturn(0);
         
-        InsertGymFailedExcetpion insertGymFailedExcetpion
-            = assertThrows(InsertGymFailedExcetpion.class,
+        InsertGymFailedException insertGymFailedException
+            = assertThrows(InsertGymFailedException.class,
             () -> gymService.insertGym(signUpGymRequestGym));
         
         assertEquals("Insert Gym failed exception",
-            insertGymFailedExcetpion.getMessage());
+            insertGymFailedException.getMessage());
     }
     
     @Test
@@ -179,7 +179,7 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("Email과 Password로 GymDTO 조회 실패 : 해당 운동시설 관리자 계정 없음 예외")
+    @DisplayName("Email과 Password로 GymDTO 조회 실패 : 해당 운동시설 관리자 계정 없음 예외 발생")
     public void findGymByEmailAndPassword_Fail() {
         String email = "test@example.com";
         String password = "test";
@@ -205,7 +205,7 @@ class GymServiceImplTest {
     }
     
     @Test
-    @DisplayName("운동 시설 관리자 계정 삭제 실패 : 삭제 쿼리 실패")
+    @DisplayName("운동 시설 관리자 계정 삭제 실패 : 데이터 베이스 명령에 실패하면 GymDeleteFailedException을 발생시킨다.")
     public void deleteGym_Fail() {
         given(gymMapper.deleteGymById(eq(1004L))).willReturn(0);
         

--- a/helparty/src/test/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImplTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImplTest.java
@@ -109,7 +109,7 @@ public class MateBoardServiceImplTest {
     }
     
     @Test
-    @DisplayName("동행구함 게시물 삭제 실패 : DB에서 삭제 실패 예외")
+    @DisplayName("동행구함 게시물 삭제 실패 : 데이터베이스 삭제 명령에 실패하면 DeleteMateBoardFailedException을 발생시킨다.")
     public void deleteMate_Fail_DeleteMateBoardFailedException() {
         String email = "test@example.com";
         


### PR DESCRIPTION
이슈번호 : #51 
## 작업 내용
- [x] 운동시설 관리자 회원 탈퇴 API 개발
- [x] 테스트 코드 
- [x] 일반 User 계정 삭제 로직에서 이메일과 비밀번호 확인 로직 삭제.  이유: @ValidateUser를 통해서 계정 권한을 확인하기 때문에 다시 이메일과 비밀번호로 확인할 필요 없어졌습니다.

## Api
- [x] deleteGym