### PR TITLE
Redis session과 cache 스토리지 분리

### DIFF
--- a/helparty/build.gradle
+++ b/helparty/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'mysql:mysql-connector-java'
     implementation 'org.projectlombok:lombok:1.18.16'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/helparty/src/main/java/com/hamryt/helparty/config/RedisSessionConfig.java
+++ b/helparty/src/main/java/com/hamryt/helparty/config/RedisSessionConfig.java
@@ -1,0 +1,43 @@
+package com.hamryt.helparty.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisSessionConfig {
+    
+    @Value("${spring.redis.session.port}")
+    public int port;
+    
+    @Value("${spring.redis.session.host}")
+    public String host;
+    
+    @Primary
+    @Bean(name = "redisSessionConnectionFactory")
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+    
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+        @Qualifier("redisSessionConnectionFactory") RedisConnectionFactory connectionFactory
+    ) {
+        
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setEnableTransactionSupport(true);
+        
+        return redisTemplate;
+    }
+    
+}

--- a/helparty/src/main/java/com/hamryt/helparty/service/gymboard/GymBoardServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/gymboard/GymBoardServiceImpl.java
@@ -41,7 +41,7 @@ public class GymBoardServiceImpl implements GymBoardService {
     }
     
     @Transactional(readOnly = true)
-    @Cacheable(value = "gymboards")
+    @Cacheable(cacheNames = "gymboards", key = "#page")
     public List<GetGymBoardResponse> getGymBoards(int page, int size) {
         return gymBoardMapper.findGymBoardsByPage(page * size, size).stream()
             .map(GetGymBoardResponse::of).collect(Collectors.toList());

--- a/helparty/src/main/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImpl.java
@@ -54,7 +54,7 @@ public class MateBoardServiceImpl implements MateBoardService {
     }
     
     @Transactional(readOnly = true)
-    @Cacheable(value = "mateboards")
+    @Cacheable(cacheNames = "mateboards", key = "#page")
     public List<GetMateBoardResponse> getMates(int page, int size) {
         return mateBoardMapper.findMateBoardByPage(page * size, size);
     }

--- a/helparty/src/main/resources/application-dev.yml
+++ b/helparty/src/main/resources/application-dev.yml
@@ -5,8 +5,12 @@ spring:
     username: root
     password: 1234
   redis:
-    host: localhost
-    port: 6379
+    session:
+      host: localhost
+      port: 6379
+    cache:
+      host: localhost
+      port: 6378
 mybatis:
   config-location: classpath:mybatis-config.xml
   configuration:

--- a/helparty/src/main/resources/application.yml
+++ b/helparty/src/main/resources/application.yml
@@ -1,7 +1,10 @@
-## Database 설정
 spring:
   profiles:
     active: dev
+  session:
+    store-type: redis
+  cache:
+    type: redis
 ---
 logging:
   config: classpath:log4j2.yml


### PR DESCRIPTION
이슈번호: #71 

### 작업내용
1. 세션을 저장하기 위해 Redis Session 저장소 생성
Redis의 session 저장소와 cache 저장소를 분리하기 위해 작업 내용에 따라 RedisSessionConfig와 RedisCacheConfig로 클래스를 분리하였습니다. 

2. Redis cache에 저장할 때 캐시이름과 키 값 부여
Map 형태로 장점을 활용할 수 있고 검색의 효율을 높이기 위해 키 값 부여하였습니다.