### PR TITLE
[#73] 데이터에 조작 트랜잭션 발생시, Cache에 있는 데이터 초기화

### DIFF
--- a/helparty/src/main/java/com/hamryt/helparty/service/gymboard/GymBoardServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/gymboard/GymBoardServiceImpl.java
@@ -8,11 +8,15 @@ import com.hamryt.helparty.exception.board.gymboard.GymBoardNotFoundException;
 import com.hamryt.helparty.exception.board.gymboard.InsertGymBoardFailedException;
 import com.hamryt.helparty.mapper.GymBoardMapper;
 import com.hamryt.helparty.service.product.ProductService;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.hamryt.helparty.util.CacheNames;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,37 +25,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class GymBoardServiceImpl implements GymBoardService {
-    
+
     private final GymBoardMapper gymBoardMapper;
     private final ProductService productService;
-    
+
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.GYMBOARD, allEntries = true)
     public void insertGymBoard(CreateGymBoardRequest createGymBoardRequest, Long loginId) {
         createGymBoardRequest.getUserType().validEqualUserType("GYM");
-        
+
         SimpleGymBoard simpleGymBoard = SimpleGymBoard.of(createGymBoardRequest, loginId);
-        
+
         if (gymBoardMapper.insertGymBoard(simpleGymBoard) != 1) {
             log.error("Insert GymBoard query failed : " + simpleGymBoard);
             throw new InsertGymBoardFailedException();
         }
-        
+
         productService
             .insertProduct(createGymBoardRequest.getProductList(), simpleGymBoard.getId());
     }
-    
+
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = "gymboards", key = "#page")
+    @Cacheable(cacheNames = CacheNames.GYMBOARD, key = "#page")
     public List<GetGymBoardResponse> getGymBoards(int page, int size) {
         return gymBoardMapper.findGymBoardsByPage(page * size, size).stream()
             .map(GetGymBoardResponse::of).collect(Collectors.toList());
     }
-    
+
     @Transactional(readOnly = true)
     public GetGymBoardResponse getGymBoard(Long id) {
         GymBoardDTO gymBoardDTO = Optional.ofNullable(gymBoardMapper.findGymBoardById(id))
             .orElseThrow(GymBoardNotFoundException::new);
-        
+
         return GetGymBoardResponse.of(gymBoardDTO);
     }
 }

--- a/helparty/src/main/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/mateboard/MateBoardServiceImpl.java
@@ -16,6 +16,8 @@ import com.hamryt.helparty.mapper.MateBoardMapper;
 import com.hamryt.helparty.service.user.UserService;
 import java.util.List;
 import java.util.Optional;
+
+import com.hamryt.helparty.util.CacheNames;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -25,18 +27,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class MateBoardServiceImpl implements MateBoardService {
-    
+
     private final UserService userService;
     private final MateBoardMapper mateBoardMapper;
-    
+
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.MATEBOARD, allEntries = true)
     public CreateMateBoardResponse addMateBoard(
         CreateMateBoardRequest createMateBoardRequest,
         Long id
     ) {
         createMateBoardRequest.getUserType().validEqualUserType("USER");
         UserDTO user = userService.findUserById(id);
-        
+
         MateBoardDTO mateBoard
             = MateBoardDTO.builder()
             .gym(createMateBoardRequest.getGym())
@@ -46,60 +49,60 @@ public class MateBoardServiceImpl implements MateBoardService {
             .userId(user.getId())
             .user(user)
             .build();
-        
+
         if (mateBoardMapper.insertMateBoard(mateBoard) != 1) {
             throw new InsertMateBoardFailedException();
         }
         return CreateMateBoardResponse.of(mateBoard);
     }
-    
+
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = "mateboards", key = "#page")
+    @Cacheable(cacheNames = CacheNames.MATEBOARD, key = "#page")
     public List<GetMateBoardResponse> getMates(int page, int size) {
         return mateBoardMapper.findMateBoardByPage(page * size, size);
     }
-    
+
     @Transactional(readOnly = true)
     public GetMateBoardResponse getMate(Long id) {
         return Optional.ofNullable(mateBoardMapper.findMateBoardById(id))
             .orElseThrow(() -> new MateBoardNotFoundException(id));
     }
-    
+
     @Transactional
-    @CacheEvict(value = "mateboards")
+    @CacheEvict(cacheNames = CacheNames.MATEBOARD, allEntries = true)
     public UpdateMateBoardResponse updateMateBoard(
         Long loginId, long boardId,
         UpdateMateBoardRequest updateMateBoardRequest
     ) {
         Long userId = mateBoardMapper.findUserIdByMateBoardId(boardId);
-        
+
         if (!loginId.equals(userId)) {
             throw new LoginUserDoesNotMatchException(loginId);
         }
-        
+
         UpdateMateBoardResponse updateMateBoardResponse = UpdateMateBoardResponse
             .of(boardId, updateMateBoardRequest);
-        
+
         if (mateBoardMapper.updateMateBoard(updateMateBoardResponse) != 1) {
             throw new UpdateFailedException(boardId);
         }
-        
+
         return updateMateBoardResponse;
     }
-    
+
     @Transactional
-    @CacheEvict(value = "mateboards")
+    @CacheEvict(cacheNames = CacheNames.MATEBOARD, allEntries = true)
     public void deleteMateBoard(long boardId, Long loginId) {
-        
+
         Long boardUserId = mateBoardMapper.findUserIdByMateBoardId(boardId);
-        
+
         if (!boardUserId.equals(loginId)) {
             throw new LoginUserDoesNotMatchException(loginId);
         }
-        
+
         if (mateBoardMapper.deleteMateBoardById(boardId) != 1) {
             throw new DeleteMateBoardFailedException();
         }
     }
-    
+
 }

--- a/helparty/src/main/java/com/hamryt/helparty/util/CacheNames.java
+++ b/helparty/src/main/java/com/hamryt/helparty/util/CacheNames.java
@@ -1,0 +1,9 @@
+package com.hamryt.helparty.util;
+
+public class CacheNames {
+
+    public static final String MATEBOARD = "mateboard";
+
+    public static final String GYMBOARD = "gymboard";
+
+}


### PR DESCRIPTION
이슈번호 : #73 

## 작업 의도
데이터베이스의 값과 redis 캐시 메모리 데이터 값의 정합성을 유지하기 위함 

## 작업 내용
데이터베이스에 데이터 조작연산이 이루어지면 cache에 있는 값을 초기화 했습니다.