### PR TITLE
[#82] ProductService의 매개변수 Wrapper클래스로 변경

### DIFF
--- a/helparty/src/main/java/com/hamryt/helparty/service/product/ProductService.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/product/ProductService.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 public interface ProductService {
 
-    void insertProductList(List<ProductDTO> productList, long gymBoardId);
+    void insertProductList(List<ProductDTO> productList, Long gymBoardId);
 
-    void updateProductList(List<ProductDTO> productList, long gymBoardId);
+    void updateProductList(List<ProductDTO> productList, Long gymBoardId);
 
-    void deleteProductList(List<Integer> deleteProductIdList, long gymBoardId);
+    void deleteProductList(List<Integer> deleteProductIdList, Long gymBoardId);
 }

--- a/helparty/src/main/java/com/hamryt/helparty/service/product/ProductServiceImpl.java
+++ b/helparty/src/main/java/com/hamryt/helparty/service/product/ProductServiceImpl.java
@@ -20,7 +20,7 @@ public class ProductServiceImpl implements ProductService {
     private final ProductMapper productMapper;
 
     @Transactional
-    public void insertProductList(List<ProductDTO> productList, long gymBoardId) {
+    public void insertProductList(List<ProductDTO> productList, Long gymBoardId) {
 
         if (productMapper.insertProductList(productList, gymBoardId) != productList.size()) {
             throw new InsertProductFailedException(
@@ -29,7 +29,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Transactional
-    public void updateProductList(List<ProductDTO> productList, long gymBoardId) {
+    public void updateProductList(List<ProductDTO> productList, Long gymBoardId) {
 
         if (productMapper.updateProductList(productList, gymBoardId) != 1) {
             throw new UpdateProductFailedException(
@@ -38,7 +38,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Transactional
-    public void deleteProductList(List<Integer> deleteProductIdList, long gymBoardId) {
+    public void deleteProductList(List<Integer> deleteProductIdList, Long gymBoardId) {
 
         if (productMapper.deleteProductList(deleteProductIdList, gymBoardId) != 1) {
             throw new DeleteProductFailedException(

--- a/helparty/src/test/java/com/hamryt/helparty/service/product/ProductServiceImplTest.java
+++ b/helparty/src/test/java/com/hamryt/helparty/service/product/ProductServiceImplTest.java
@@ -1,26 +1,25 @@
 package com.hamryt.helparty.service.product;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
 import com.hamryt.helparty.dto.board.product.ProductDTO;
 import com.hamryt.helparty.dto.board.product.ProductDTO.BoardType;
 import com.hamryt.helparty.exception.product.DeleteProductFailedException;
 import com.hamryt.helparty.exception.product.InsertProductFailedException;
 import com.hamryt.helparty.exception.product.UpdateProductFailedException;
 import com.hamryt.helparty.mapper.ProductMapper;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceImplTest {
@@ -59,7 +58,7 @@ class ProductServiceImplTest {
 
         InsertProductFailedException insertProductFailedException
             = assertThrows(InsertProductFailedException.class,
-            () -> productService.insertProductList(mockProductList, 1004));
+            () -> productService.insertProductList(mockProductList, 1004L));
 
         assertEquals("데이터베이스에 상품 리스트 insert 실패. gymBoardId: " + 1004,
             insertProductFailedException.getMessage());
@@ -110,7 +109,7 @@ class ProductServiceImplTest {
 
         DeleteProductFailedException deleteProductFailedException
             = assertThrows(DeleteProductFailedException.class,
-            () -> productService.deleteProductList(deleteProductIdList, 1004));
+            () -> productService.deleteProductList(deleteProductIdList, 1004L));
 
         assertEquals("데이터베이스에 상품 리스트 Delete 실패. gymBoardId: 1004", deleteProductFailedException.getMessage());
     }


### PR DESCRIPTION
이슈번호 : #82 

매개변수를 원시타입으로 지정하는 것이 테스트코드 작성에서 mocking하는데 불편하다고 생각되어 Wrapper클래스로 변환하였습니다. 